### PR TITLE
fix: adjust linter output to github env

### DIFF
--- a/.github/workflows/test_action.yml
+++ b/.github/workflows/test_action.yml
@@ -1,8 +1,8 @@
 ---
 on:
   push:
-#    branches:
-#      - master
+    branches:
+      - master
 jobs:
   test_action:
     name: Test this action
@@ -13,7 +13,7 @@ jobs:
 
       - name: Run action
         id: run_action
-        uses: beiertu-mms/yamllint-composite-action@fix/fix-lint-output
+        uses: beiertu-mms/yamllint-composite-action@master
         with:
           files_or_dirs: .github/test
 

--- a/.github/workflows/test_action.yml
+++ b/.github/workflows/test_action.yml
@@ -1,8 +1,8 @@
 ---
 on:
   push:
-    branches:
-      - master
+#    branches:
+#      - master
 jobs:
   test_action:
     name: Test this action
@@ -13,7 +13,7 @@ jobs:
 
       - name: Run action
         id: run_action
-        uses: beiertu-mms/yamllint-composite-action@master
+        uses: beiertu-mms/yamllint-composite-action@fix/fix-lint-output
         with:
           files_or_dirs: .github/test
 

--- a/action.yml
+++ b/action.yml
@@ -24,12 +24,10 @@ inputs:
     description: "Output only error level problems"
     required: false
     default: "false"
-#  -f {parsable,standard,colored,github,auto}, --format {parsable,standard,colored,github,auto}
-#                        format for parsing output
 outputs:
   lint_output:
     description: "Result from yamllint"
-    value: ${{ steps.lint.outputs.result }}
+    value: ${{ steps.lint.outputs.lint_output }}
 runs:
   using: "composite"
   steps:

--- a/action.yml
+++ b/action.yml
@@ -71,7 +71,7 @@ runs:
         strict: ${{ steps.params.outputs.yamllint_strict }}
         no_warnings: ${{ steps.params.outputs.yamllint_no_warnings }}
       run: |
-        yamllint ${{ inputs.files_or_dirs }} --format standard \
+        yamllint ${{ inputs.files_or_dirs }} --format github \
           ${{ env.config_file }} \
           ${{ env.config_data }} \
           ${{ env.strict }} \

--- a/action.yml
+++ b/action.yml
@@ -73,7 +73,7 @@ runs:
         strict: ${{ steps.params.outputs.yamllint_strict }}
         no_warnings: ${{ steps.params.outputs.yamllint_no_warnings }}
       run: |
-        yamllint ${{ inputs.files_or_dirs }} \
+        yamllint ${{ inputs.files_or_dirs }} --format standard \
           ${{ env.config_file }} \
           ${{ env.config_data }} \
           ${{ env.strict }} \
@@ -81,5 +81,7 @@ runs:
 
         cat result.txt
 
-        echo "lint_output=test" >> "$GITHUB_OUTPUT"
+        echo "lint_output<<EOF" >> "$GITHUB_OUTPUT"
+        cat result.txt >> "$GITHUB_OUTPUT"
+        echo "EOF" >> "$GITHUB_OUTPUT"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -71,12 +71,13 @@ runs:
         strict: ${{ steps.params.outputs.yamllint_strict }}
         no_warnings: ${{ steps.params.outputs.yamllint_no_warnings }}
       run: |
-        yamllint ${{ inputs.files_or_dirs }} --format github \
+        yamllint ${{ inputs.files_or_dirs }} --format auto \
           ${{ env.config_file }} \
           ${{ env.config_data }} \
           ${{ env.strict }} \
           ${{ env.no_warnings }} > result.txt
 
+        echo "Yamllint result:"
         cat result.txt
 
         echo "result<<EOF" >> "$GITHUB_OUTPUT"

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
 outputs:
   lint_output:
     description: "Result from yamllint"
-    value: ${{ steps.lint.outputs.lint_output }}
+    value: ${{ steps.lint.outputs.result }}
 runs:
   using: "composite"
   steps:
@@ -79,7 +79,7 @@ runs:
 
         cat result.txt
 
-        echo "lint_output<<EOF" >> "$GITHUB_OUTPUT"
+        echo "result<<EOF" >> "$GITHUB_OUTPUT"
         cat result.txt >> "$GITHUB_OUTPUT"
         echo "EOF" >> "$GITHUB_OUTPUT"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -73,14 +73,13 @@ runs:
         strict: ${{ steps.params.outputs.yamllint_strict }}
         no_warnings: ${{ steps.params.outputs.yamllint_no_warnings }}
       run: |
-        result=$(yamllint ${{ inputs.files_or_dirs }} \
+        yamllint ${{ inputs.files_or_dirs }} \
           ${{ env.config_file }} \
           ${{ env.config_data }} \
           ${{ env.strict }} \
-          ${{ env.no_warnings }} \
-          | sed 's/::group:://g;s/::endgroup:://g')
+          ${{ env.no_warnings }} > result.txt
 
-        echo "$result"
+        cat result.txt
 
-        echo "lint_output=$result" >> "$GITHUB_OUTPUT"
+        echo "lint_output=test" >> "$GITHUB_OUTPUT"
       shell: bash


### PR DESCRIPTION
The yamllint output is a multi-line string and therefore it needs to be outputted differently.
See [GitHub docs about Multiline strings](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings).
