### PR TITLE
feat(action): add format option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,30 @@ jobs:
         run: echo ${{ steps.yamllint.outputs.lint_output }}
 ```
 
+### Version
+
+This action also provide specific versions to be used with. For example
+
+```yaml
+- uses: beiertu/yamllint-composite-action@v1.0.0
+```
+
+See [this action releases][releases] for all available versions.
+
+[releases]: https://github.com/beiertu-mms/yamllint-composite-action/releases
+
 ## Inputs
 
 This action accepts the following inputs.
 
-| Name            | Description                                                 | Required |          Default          |
-|-----------------|-------------------------------------------------------------|:--------:|:-------------------------:|
-| `files_or_dirs` | A space separated list of files or directories to be linted |    no    | current working directory |
-| `config_file`   | Path to a custom configuration file                         |    no    |            ""             |
-| `config_data`   | Custom configuration (as YAML source)                       |    no    |            ""             |
-| `strict`        | Return non-zero exit code on warnings as well as errors     |    no    |           false           |
-| `no_warnings`   | Output only error level problems                            |    no    |           false           |
+| Name            | Description                                                                                 | Required |          Default          |
+|-----------------|---------------------------------------------------------------------------------------------|:--------:|:-------------------------:|
+| `files_or_dirs` | A space separated list of files or directories to be linted                                 |    no    | current working directory |
+| `config_file`   | Path to a custom configuration file                                                         |    no    |            ""             |
+| `config_data`   | Custom configuration (as YAML source)                                                       |    no    |            ""             |
+| `strict`        | Return non-zero exit code on warnings as well as errors                                     |    no    |           false           |
+| `no_warnings`   | Output only error level problems                                                            |    no    |           false           |
+| `format`        | The format for parsing output. Available options: parsable, standard, colored, github, auto |    no    |           auto            |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: "Output only error level problems"
     required: false
     default: "false"
+  format:
+    description: "The format for parsing output. Available options: parsable, standard, colored, github, auto"
+    required: false
+    default: "auto"
 outputs:
   lint_output:
     description: "Result from yamllint"
@@ -72,7 +76,7 @@ runs:
         strict: ${{ steps.params.outputs.yamllint_strict }}
         no_warnings: ${{ steps.params.outputs.yamllint_no_warnings }}
       run: |
-        yamllint ${{ inputs.files_or_dirs }} --format auto \
+        yamllint ${{ inputs.files_or_dirs }} --format ${{ inputs.format }} \
           ${{ env.config_file }} \
           ${{ env.config_data }} \
           ${{ env.strict }} \


### PR DESCRIPTION
Give user the possibility to set the output format.
This is useful when using the output as a pull request comment.
As the default is auto and when running in a github workflow, the comment might look strange

![image](https://user-images.githubusercontent.com/44575474/224319401-bea371a7-8e05-4734-9965-42b4433a2fe8.png)
