### PR TITLE
fix(action): fix input config_data

### DIFF
--- a/.github/workflows/test_action.yml
+++ b/.github/workflows/test_action.yml
@@ -16,6 +16,7 @@ jobs:
         uses: beiertu-mms/yamllint-composite-action@master
         with:
           files_or_dirs: .github/test
+          config_data: '{extends: default, rules: {line-length: {max: 120}}}'
 
       - name: Output
         run: echo "${{ steps.run_action.outputs.lint_output }}"

--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,7 @@ runs:
 
         YAMLLINT_CONFIG_DATA=""
         if [[ -n "${{ inputs.config_data }}" ]]; then
-          YAMLLINT_CONFIG_DATA="--config-data ${{ inputs.config_data }}"
+          YAMLLINT_CONFIG_DATA="--config-data '${{ inputs.config_data }}'"
         fi
 
         YAMLLINT_STRICT=""


### PR DESCRIPTION
The value for the option `config_data` can contain spaces, as it's a serialized YAML object (see also [yamllint doc](https://yamllint.readthedocs.io/en/stable/configuration.html#custom-configuration-without-a-config-file)).
Therefore it needs to be enclosed with quotes to prevent the shell to interpret the value as arguments.

Otherwise the given configuration will be interpret as arguments and
yamllint will complain, which looks something like

```sh
yamllint . --format auto \
    --config-data {extends: default, rules: {line-length: {max: 120}}}
  
usage: yamllint [-h] [-] [-c CONFIG_FILE | -d CONFIG_DATA] [--list-files]
                [-f {parsable,standard,colored,github,auto}] [-s]
                [--no-warnings] [-v]
                [FILE_OR_DIR ...]
yamllint: error: unrecognized arguments: default, rules: {line-length: {max: 120}}}
```
